### PR TITLE
Build warnings fixed

### DIFF
--- a/AI/HNN/FF/Network.hs
+++ b/AI/HNN/FF/Network.hs
@@ -216,13 +216,13 @@ fromWeightMatrices ws = Network ws
 
 -- | Computes the output of the network on the given input vector with the given activation function
 output :: (Floating (Vector a), Product a, Storable a, Num (Vector a)) => Network a -> ActivationFunction a -> Vector a -> Vector a
-output (Network{..}) act input = V.foldl' f (join [input, 1]) matrices
+output (Network{..}) act input = V.foldl' f (vjoin [input, 1]) matrices
   where f !inp m = mapVector act $ m <> inp
 {-# INLINE output #-}
 
 -- | Computes and keeps the output of all the layers of the neural network with the given activation function
 outputs :: (Floating (Vector a), Product a, Storable a, Num (Vector a)) => Network a -> ActivationFunction a -> Vector a -> V.Vector (Vector a)
-outputs (Network{..}) act input = V.scanl f (join [input, 1]) matrices
+outputs (Network{..}) act input = V.scanl f (vjoin [input, 1]) matrices
   where f !inp m = mapVector act $ m <> inp
 {-# INLINE outputs #-}
 

--- a/AI/HNN/Recurrent/Network.hs
+++ b/AI/HNN/Recurrent/Network.hs
@@ -56,7 +56,7 @@ module AI.HNN.Recurrent.Network (
 
 import System.Random.MWC
 import Control.Monad
-import Numeric.LinearAlgebra
+import Numeric.LinearAlgebra hiding (i)
 import Foreign.Storable as F
 
 -- | Our recurrent neural network
@@ -92,7 +92,7 @@ computeStep :: (Variate a, Num a, F.Storable a, Product a) =>
 computeStep (Network{..}) state activation input =
     mapVector activation $! zipVectorWith (-) (weights <> prefixed) thresh
     where
-        prefixed = Numeric.LinearAlgebra.join
+        prefixed = Numeric.LinearAlgebra.vjoin
             [ input, (subVector nInputs (size-nInputs) state) ]
         {-# INLINE prefixed #-}
 
@@ -110,7 +110,7 @@ evalNet n@(Network{..}) inputs activation = do
     where
         state = fromList $ replicate size 0.0
         {-# INLINE state #-}
-        computeStepM n s a i = return $ computeStep n s a i
+        computeStepM _ s a i = return $ computeStep n s a i
         {-# INLINE computeStepM #-}
         inputsV = map (fromList) inputs
         {-# INLINE inputsV #-}


### PR DESCRIPTION
Fixed the build warnings :
- Warning about shadowing `i` imported from Numeric.LinearAlgebra was fixed by hiding `i`
- Warning about shadowing `n` on line 113 in the computeStepM function was fixed by ignoring the second argument (it's always passed the `n` in the outer scope)
- Warnings about the use of `join`s was fixed by using `vjoin` instead
