### PR TITLE
cabal: upper bounds on hmatrix

### DIFF
--- a/hnn.cabal
+++ b/hnn.cabal
@@ -1,7 +1,7 @@
 name:                hnn
 version:             0.2.0.0
 synopsis:            A reasonably fast and simple neural network library
-description:         
+description:
     .
     A neural network library implemented purely in Haskell, relying on the
     hmatrix library.
@@ -29,7 +29,7 @@ library
     base >=4 && <5,
     vector,
     mwc-random,
-    hmatrix >= 0.16,
+    hmatrix >= 0.16 && < 0.17,
     random,
     vector-binary-instances >= 0.2,
     binary,


### PR DESCRIPTION
compiles:

```
% stack install
hnn-0.2.0.0: unregistering (local file changes)
hnn-0.2.0.0: build
Preprocessing library hnn-0.2.0.0...
[2 of 2] Compiling AI.HNN.FF.Network ( AI/HNN/FF/Network.hs, .stack-work/dist/x86_64-linux/Cabal-1.22.5.0/build/AI/HNN/FF/Network.o )
In-place registering hnn-0.2.0.0...
hnn-0.2.0.0: install
Installing library in
/home/jchee/packages/hnn/.stack-work/install/x86_64-linux/lts-5.2/7.10.3/lib/x86_64-linux-ghc-7.10.3/hnn-0.2.0.0-DNbRjPeg2K4LOTEbyCmbeT
Registering hnn-0.2.0.0...
```
